### PR TITLE
chore: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -30,7 +30,7 @@ jobs:
         run: pnpm run docs:build
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'doocs/jvm'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Compress Images
         id: calibre

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -11,11 +11,11 @@ jobs:
     if: github.repository == 'doocs/jvm'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
 
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43 # 1.5.0
+        uses: calibreapp/image-actions@1.5.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
@@ -31,6 +31,6 @@ jobs:
       - name: Push Changes
         if: |
           steps.calibre.outputs.markdown != ''
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
+        uses: ad-m/github-push-action@v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -32,7 +32,7 @@ jobs:
         run: echo "jvm.doocs.org" > docs/.vitepress/dist/CNAME
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` v5 → v7 across all workflows
- Upgrade `pnpm/action-setup` v4 → v6 in deploy and Cloudflare workflows
- Upgrade `actions/upload-pages-artifact` v3 → v5 and `actions/deploy-pages` v4 → v5 for GitHub Pages
- Upgrade `cloudflare/wrangler-action` v3 → v4 to match Wrangler v4 in `package.json`
- Pin `actions/checkout` to v7.0.0 SHA in compress workflow (calibreapp/image-actions and github-push-action already at latest)

## Test plan

- [ ] Verify `Build and deploy` workflow runs successfully on merge
- [ ] Verify `Deploy to Cloudflare Workers` workflow runs successfully on merge
- [ ] Confirm scheduled `Compress` workflow still works (or trigger via workflow_dispatch)