### PR TITLE
fix: require Node 22.12+ and keep a single pnpm override source

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://jvm.doocs.org",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.12.0"
   },
   "devDependencies": {
     "typescript": "^7.0.2",
@@ -32,17 +32,5 @@
     "cf:types": "wrangler types",
     "deploy:cf": "pnpm run docs:build && wrangler deploy"
   },
-  "packageManager": "pnpm@10.33.0",
-  "pnpm": {
-    "overrides": {
-      "vite": "8.2.2",
-      "esbuild": "0.28.2",
-      "postcss": "8.5.26",
-      "nanoid": "3.3.18"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "workerd"
-    ]
-  }
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@ overrides:
   nanoid: 3.3.18
   postcss: 8.5.26
   vite: 8.2.2
+
+onlyBuiltDependencies:
+  - esbuild
+  - workerd


### PR DESCRIPTION
## Summary

Follow-up to Copilot review on #57.

- Tighten `engines.node` to `>=22.12.0` because `wrangler@4.125.0` requires Node 22+ and Vite 8 excludes 22.0-22.11
- Move `overrides` and `onlyBuiltDependencies` fully into `pnpm-workspace.yaml` so they are not duplicated in `package.json`

CI already uses Node 22.

## Test plan

- [x] `pnpm install` — lockfile unchanged, workerd/esbuild still allowed
- [ ] Confirm CI on Node 22 still passes

Made with [Cursor](https://cursor.com)